### PR TITLE
Fixed: Missing promisify

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,6 +10,7 @@ const { pair, startPairing } = require('./pairing');
 const { verify } = require('./verifying');
 const prompt = require('prompt');
 const plist = require('simple-plist');
+const { promisify } = require('utils');
 
 class AtvClient extends EventEmitter {
   constructor(deviceId, host, port) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ const { pair, startPairing } = require('./pairing');
 const { verify } = require('./verifying');
 const prompt = require('prompt');
 const plist = require('simple-plist');
-const { promisify } = require('utils');
+const { promisify } = require('util');
 
 class AtvClient extends EventEmitter {
   constructor(deviceId, host, port) {


### PR DESCRIPTION
`pinPrompt()` does not run because `util.promisify` is not loaded.