### PR TITLE
Fixed: Missing authKey

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -98,7 +98,7 @@ class AtvClient extends EventEmitter {
       .catch(() => {
         return startPairing(socket)
           .then(AtvClient.pinPrompt)
-          .then(pin => pair(socket, this.clientId, pin))
+          .then(pin => pair(socket, this.clientId, this.authKey, pin))
           .then(res => log.info('Pairing successful'));
       });
   }

--- a/lib/pairing.js
+++ b/lib/pairing.js
@@ -23,7 +23,7 @@ function doPairSetupPin2(socket, A, M1) {
     .then(res => plist.parse(res.body));
 }
 
-function doPairSetupPin3(socket, K) {
+function doPairSetupPin3(socket, K, authKey) {
   let aesKey = crypto.createHash('sha512').update('Pair-Setup-AES-Key').update(K).digest().slice(0, 16);
   let aesIV = crypto.createHash('sha512').update('Pair-Setup-AES-IV').update(K).digest().slice(0, 16);
   aesIV[15]++;
@@ -39,7 +39,7 @@ function doPairSetupPin3(socket, K) {
     .then(res => plist.parse(res.body));
 }
 
-function pair(socket, clientId, pin) {
+function pair(socket, clientId, authKey, pin) {
   return doPairSetupPin1(socket, clientId)
     .then(res => {
       let params = srp.params[2048];
@@ -53,7 +53,7 @@ function pair(socket, clientId, pin) {
       client.setB(res.pk);
 
       return doPairSetupPin2(socket, client.computeA(), client.computeM1())
-        .then(() => doPairSetupPin3(socket, client.computeK()));
+        .then(() => doPairSetupPin3(socket, client.computeK(), authKey));
     });
 }
 


### PR DESCRIPTION
After receiving the pin (see also #1) the pairing can't continue because the methods don't have access to the `authKey`.